### PR TITLE
lib/domains/de/falbk.txt

### DIFF
--- a/lib/domains/schule/falbk.txt
+++ b/lib/domains/schule/falbk.txt
@@ -1,0 +1,2 @@
+профессиональное училище 
+Friedrich-Alberts-Lange Berufskolleg


### PR DESCRIPTION
Please add the falbk.schule domain.

School: Friedrich-Albert-Lange Berufskolleg Duisburg-Mitte
Official website: https://www.falbk.de
This school provides IT-related long-term programs (Fachhochschulreife).
IT programs: https://falbk.de/landing-page/bildungsgangscout/gestaltungstechnik/berufliches-gymnasium-fuer-gestaltung-gestaltungstechnische-r-assistent-in-ahr
https://falbk.de/landing-page/bildungsgangscout/games_interaktive_medien/ih
